### PR TITLE
Add multiple controller support and fix input device watcher issues

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -107,7 +107,7 @@
   <target name="compile-common" depends="init">
     <!-- compile limelight -->
     <javac includeantruntime="false" destdir="${classes.dir}/common">
-      <src path="${common.src.dir}"/>java
+      <src path="${common.src.dir}"/>
       
       <classpath>
         <fileset dir="${common.libs.dir}" includes="*.jar"/>

--- a/src/com/limelight/input/EvdevAbsolute.java
+++ b/src/com/limelight/input/EvdevAbsolute.java
@@ -53,7 +53,9 @@ public class EvdevAbsolute {
 			return reverse?Short.MAX_VALUE:Short.MIN_VALUE;
 		else {
 			value += value<avg?flat:-flat;
-			return (short) ((value-avg) * Short.MAX_VALUE / (reverse?flat-range:range-flat));
+
+			// Divide the value by the range before multiplying to avoid overflowing
+			return (short) (((value-avg) / (float)(reverse?flat-range:range-flat)) * 0x7FFE);
 		}
 	}
 	

--- a/src/com/limelight/input/EvdevLoader.java
+++ b/src/com/limelight/input/EvdevLoader.java
@@ -90,14 +90,16 @@ public class EvdevLoader implements Runnable {
 			WatchService watcher = evdev.getFileSystem().newWatchService();
 			evdev.register(watcher, StandardWatchEventKinds.ENTRY_CREATE);
 			
-			WatchKey watckKey = watcher.take();
-			List<WatchEvent<?>> events = watckKey.pollEvents();
-			for (WatchEvent event:events) {
-				if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
-					String name = event.context().toString();
-					if (filter.accept(input, name)) {
-						LimeLog.info("Input " + name + " added");
-						new EvdevHandler(conn, new File(input, name).getAbsolutePath(), mapping).start();
+			for (;;) {
+				WatchKey watckKey = watcher.take();
+				List<WatchEvent<?>> events = watckKey.pollEvents();
+				for (WatchEvent event:events) {
+					if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+						String name = event.context().toString();
+						if (filter.accept(input, name)) {
+							LimeLog.info("Input " + name + " added");
+							new EvdevHandler(conn, new File(input, name).getAbsolutePath(), mapping).start();
+						}
 					}
 				}
 			}

--- a/src/com/limelight/input/EvdevLoader.java
+++ b/src/com/limelight/input/EvdevLoader.java
@@ -91,8 +91,8 @@ public class EvdevLoader implements Runnable {
 			evdev.register(watcher, StandardWatchEventKinds.ENTRY_CREATE);
 			
 			for (;;) {
-				WatchKey watckKey = watcher.take();
-				List<WatchEvent<?>> events = watckKey.pollEvents();
+				WatchKey watchKey = watcher.take();
+				List<WatchEvent<?>> events = watchKey.pollEvents();
 				for (WatchEvent event:events) {
 					if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
 						String name = event.context().toString();
@@ -101,6 +101,10 @@ public class EvdevLoader implements Runnable {
 							new EvdevHandler(conn, new File(input, name).getAbsolutePath(), mapping).start();
 						}
 					}
+				}
+				
+				if (!watchKey.reset()) {
+					break;
 				}
 			}
 		} catch (IOException | InterruptedException ex) {

--- a/src/com/limelight/input/EvdevReader.java
+++ b/src/com/limelight/input/EvdevReader.java
@@ -43,6 +43,7 @@ public abstract class EvdevReader implements Runnable {
 	}
 	
 	protected abstract void parseEvent(ByteBuffer buffer);
+	protected abstract void deviceRemoved();
 	
 	@Override
 	public void run() {
@@ -54,6 +55,7 @@ public abstract class EvdevReader implements Runnable {
 			}
 		} catch (IOException e) {
 			LimeLog.warning("Input device removed");
+			deviceRemoved();
 		}
 	}
 

--- a/src/com/limelight/input/GamepadMapper.java
+++ b/src/com/limelight/input/GamepadMapper.java
@@ -75,6 +75,11 @@ public class GamepadMapper extends EvdevReader {
 			notify();		
 		}
 	}
+
+	@Override
+	protected void deviceRemoved() {
+		// Nothing for us to do
+	}
 	
 	public synchronized void readKey(String key, String name) throws InterruptedException {
 		System.out.println(name);


### PR DESCRIPTION
I've added support for multiple controllers. It works in the same way Limelight Android works now.

Controller IDs are assigned on the first input and released when the input device goes away. This mostly solves the problem of wireless xbox dongle exposing input devices for controllers that haven't connected yet. Determining when a single controller disconnects is still impossible on these dongles, but disconnecting the dongle itself releases all child controller IDs.

In the process, I found bugs in the input device watcher which prevented it from detecting more than one set of input device creation events. If you plugged one in (detected fine), unplugged it, then plugged it in again, it wouldn't be detected again. Those bugs are fixed in this PR too.

I also removed some extra text from build.xml that was breaking build.