### PR TITLE
Fix analog stick axis overflow issue

### DIFF
--- a/src/com/limelight/input/EvdevAbsolute.java
+++ b/src/com/limelight/input/EvdevAbsolute.java
@@ -53,7 +53,7 @@ public class EvdevAbsolute {
 			return reverse?Short.MAX_VALUE:Short.MIN_VALUE;
 		else {
 			value += value<avg?flat:-flat;
-			return (short) ((value-avg) * Short.MAX_VALUE / (reverse?flat-range:range-flat));
+			return (short) ((value-avg) * 0x7FFE / (reverse?flat-range:range-flat));
 		}
 	}
 	


### PR DESCRIPTION
The Xbox 360 controller has an axis inversion issue when pushed in the full positive direction (value = 32767). The current code results in the value overflowing to -32768 when run on the Pi (2). With this patch, the overflow is avoided and the sticks act as expected. On Android, I'm also multiplying by 0x7FFE instead of 0x7FFF for the same reason.